### PR TITLE
Don't error if there is invalid JSON in message.

### DIFF
--- a/rofi-polkit-agent
+++ b/rofi-polkit-agent
@@ -27,6 +27,12 @@ else
     # from stdin to variable $msg
     while read -r msg; do
         #  --- shellcheck disable=SC2210
+        # Test to see that we can successfully parse the message
+        if ! $(echo "$msg" | jq -e . >/dev/null 2>&1); then
+          # If we can not, remove the message.
+          msg=$(echo "$msg" | sed -rne 's/,\s"message":.*/ \}/gip')
+        fi
+
         if echo "$msg" | jq -e '.action == "request password"' 1>/dev/null 2>/dev/null
         then
             # Parse msg fields


### PR DESCRIPTION
Some applications send messages which are not valid JSON, particularly vscode. When this happens `jq` fails to parse the message and the authentication request can not proceed.

Ideally the upstream `cmd-polkit` library would fix these issues before forwarding the JSON message to the agent but in the meantime it's enough to remove the message field with `sed` if it's broken.