### PR TITLE
Exit after processing

### DIFF
--- a/rofi-polkit-agent
+++ b/rofi-polkit-agent
@@ -39,11 +39,13 @@ else
 
             # Cancel authentication if no password was given,
             # otherwise respond with given password
-            if test -z "$response"
-            then echo '{"action":"cancel"}'
-            else echo "{\"action\":\"authenticate\",\"password\": \"$response\"}"
+            if test -z "$response"; then
+              echo '{"action":"cancel"}'
+              exit 1
+            else
+              echo "{\"action\":\"authenticate\",\"password\": \"$response\"}"
+              exit 0
             fi
         fi
     done
 fi
-


### PR DESCRIPTION
Because `rofi-polkit-agent` spawns instances of itself from `cmd-polkit-agent` each time a request arrives, the agent only needs to read so long as a request is not fulfilled. New requests to `cmd-polkit-agent` will always spawn another `rofi-polkit-agent`. Over time this means users can end up with many `rofi-polkit-agent` processes stuck in a while loop waiting for messages.

Unfortunately this is not a true fix for the problem. There is an upstream bug with `cmd-polkit-agent` which causes it to not clear zombie processes properly. Over time users will still notice many zombie `rofi-polkit-agent` processes building up. However, the risk of running out of PID's is far lower than the risk of utilizing too many resources by running multiple agents perpetually.